### PR TITLE
Add version command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,8 @@
 name: release
 
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types: [released]
 
 permissions:
   contents: write

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,9 +20,6 @@ rsec also redacts secrets from the output of commands, minimizing the possible e
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	// rootCmd.SetUsageFunc(RenderUsage)
-	// rootCmd.SetHelpFunc(RenderHelp)
-
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var version string
+
+func SetVersion(v string) {
+	version = v
+}
+
+func NewVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "version",
+		Short:   "Returns the currently installed version of rsec",
+		Long:    `Returns the currently installed version of rsec`,
+		Example: `  rsec version`,
+		Run: func(cmd *cobra.Command, args []string) {
+			std := NewStd(cmd)
+			std.Out(version)
+		},
+	}
+}
+
+func init() {
+	versionCmd := NewVersionCmd()
+	rootCmd.AddCommand(versionCmd)
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,9 @@ package main
 
 import "github.com/runsecret/rsec/cmd"
 
+var Version = "local"
+
 func main() {
+	cmd.SetVersion(Version)
 	cmd.Execute()
 }


### PR DESCRIPTION
Adds a new `rsec version` command, and also return the release trigger to a manually cut Github Release