### PR TITLE
Complete Basic Hashicorp Vault Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,8 @@ rsec://myvault/kv.azure.cn/MySecret?version=1.0
 rsec://myvault/kv.azure.us/MySecret?version=1.0
 
 # Azure Germany
-rsec
+rsec://myvault/kv.azure.de/MySecret?version=1.0
+```
 
 ### Hashicorp Vault
 
@@ -312,8 +313,6 @@ Or with PowerShell:
 ```powershell
 iwr -useb https://raw.githubusercontent.com/runsecret/rsec/main/scripts/uninstall.ps1 | iex
 ```
-
-
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ RunSecret (rsec) is a CLI tool that simplifies secret management for local devel
 - [Supported Secret Vaults](#supported-secret-vaults)
   - [AWS Secrets Manager](#aws-secrets-manager)
   - [Azure Key Vault](#azure-key-vault)
-  - [Hashicorp Vault](#hashicorp-vault)
+  - [HashiCorp Vault](#hashicorp-vault)
   - [Upcoming Vault Support (Roadmap)](#upcoming-vault-support-roadmap)
 - [Uninstalling](#uninstalling)
 - [Contributing](#contributing)
@@ -39,9 +39,9 @@ It's generally a pain for the developers, and a security risk for the company. R
 
 ## How It Works
 
-RunSecret uses **secret references** to solve these problems. Think of these as pointers that replace the secrets themselves. To use RunSercet you simply:
+RunSecret uses **secret references** to solve these problems. Think of these as pointers that replace the secrets themselves. To use RunSecret you simply:
 
-1. Update your environment variabes or `.env` files with references to secrets (not the secrets themselves)
+1. Update your environment variables or `.env` files with references to secrets (not the secrets themselves)
 2. Use `rsec run` to inject actual secret values from your vault at runtime
 3. Continue using your existing development workflow with no code changes!
 
@@ -50,7 +50,7 @@ RunSecret uses **secret references** to solve these problems. Think of these as 
 - ✅ **Easy Setup**: Works with existing `.env` files and environment variables
 - ✅ **Team-Friendly**: `.env` files can be safely committed to git, making team onboarding/offboarding a breeze
 - ✅ **Vault Agnostic**: Works with multiple secret storage solutions, with more on the way
-- ✅ **Secure**: Leverages your existing vault permissions so only the who need access to secrets can get them
+- ✅ **Secure**: Leverages your existing vault permissions so only those who need access to secrets can get them
 - ✅ **Leak Prevention**: Automatically redacts secret values in logs and console output
 
 ## Installation
@@ -83,7 +83,7 @@ iwr -useb https://raw.githubusercontent.com/runsecret/rsec/main/scripts/install.
 
 1. **Authenticate with your secret vault**
 
-   Ensure your local machine is authenticated with your secrets vault. This can vary by vault provider, but often requires loging in via a provided CLI.
+   Ensure your local machine is authenticated with your secrets vault. This can vary by vault provider, but often requires logging in via a provided CLI.
 
 2. **Replace static secrets with references**
 
@@ -265,9 +265,9 @@ rsec://myvault/kv.azure.us/MySecret?version=1.0
 rsec://myvault/kv.azure.de/MySecret?version=1.0
 ```
 
-### Hashicorp Vault
+### HashiCorp Vault
 
-Supports both versions of the KV secret engine (v1 and v2) and credential-based secret enginees such as database, aws, rabbitmq, etc.
+Supports both versions of the KV secret engine (v1 and v2) and credential-based secret engines such as database, AWS, RabbitMQ, etc.
 
 **Authentication:**
 - Currently supports token-based authentication via one of the following methods:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ RunSecret (rsec) is a CLI tool that simplifies secret management for local devel
 - [Supported Secret Vaults](#supported-secret-vaults)
   - [AWS Secrets Manager](#aws-secrets-manager)
   - [Azure Key Vault](#azure-key-vault)
-  - [HashiCorp Vault](#hashicorp-vault)
+  - [Hashicorp Vault](#hashicorp-vault)
   - [Upcoming Vault Support (Roadmap)](#upcoming-vault-support-roadmap)
 - [Uninstalling](#uninstalling)
 - [Contributing](#contributing)
@@ -264,7 +264,7 @@ rsec://myvault/kv.azure.us/MySecret?version=1.0
 # Azure Germany
 rsec
 
-### HashiCorp Vault
+### Hashicorp Vault
 
 Supports both versions of the KV secret engine (v1 and v2) and credential-based secret enginees such as database, aws, rabbitmq, etc.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Secret Reference:  rsec://012345678912/sm.aws/MyTestSecret?region=us-east-1
 Vault Address: arn:aws:secretsmanager:us-east-1:012345678912:secret:MyDatabasePassword
 ```
 
-For specific examples for your vault provider, see the relevant [Supported Secret Vaults](#supported-secret-vaults) subsection.
+For examples specific to your vault provider, see the [Supported Secret Vaults](#supported-secret-vaults) section.
 
 ## Complete Example
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ RunSecret (rsec) is a CLI tool that simplifies secret management for local devel
 - [Complete Example](#complete-example)
 - [Commands Reference](#commands-reference)
 - [Supported Secret Vaults](#supported-secret-vaults)
+  - [AWS Secrets Manager](#aws-secrets-manager)
+  - [Azure Key Vault](#azure-key-vault)
+  - [HashiCorp Vault](#hashicorp-vault)
+  - [Upcoming Vault Support (Roadmap)](#upcoming-vault-support-roadmap)
 - [Uninstalling](#uninstalling)
 - [Contributing](#contributing)
 - [License](#license)
@@ -130,48 +134,7 @@ Secret Reference:  rsec://012345678912/sm.aws/MyTestSecret?region=us-east-1
 Vault Address: arn:aws:secretsmanager:us-east-1:012345678912:secret:MyDatabasePassword
 ```
 
-### AWS Secrets Manager
-
-Being more specific from the general format defined above, all AWS Secrets Manager references are constructed with the following values:
-```bash
-rsec://<accountNumber>/sm.aws/<secretName>?region=<region>
-```
-
-The `region` attribute is currently only applicable to AWS Secrets Manager references, and will appear on all secret references for this provider.
-
-Example:
-```
-rsec://012345678912/sm.aws/DatabasePassword?region=us-east-1
-```
-
-### Azure Key Vault
-For Azure Key Vault, the reference format is:
-```bash
-rsec://<vaultAddress>/kv.azure/<secretName>?<arguments>
-```
-
-Where:
-* `vaultAddress`: The name of the Azure Key Vault (e.g. if using `https://myvault.vault.azure.net/` then `myvault` is the vault address)
-* `secretName`: The name of the secret in the Azure Key Vault
-* `arguments`: Optional arguments, such as `version` to specify a specific version of the secret.
-
-Example:
-```
-rsec://myvault/kv.azure/MySecret?version=1.0
-```
-
-**Using Azure China/Azure Government/Azure Germany**
-If you are using Azure China, Azure Government, or Azure Germany, you can use `rsec` in the same way described above, but will replace the `kv.azure` with a region-specific value. For example, for Azure China, you would use `kv.azure.cn` instead of `kv.azure`. Example secret references for each Azure region is as follows:
-```bash
-# Azure China
-rsec://myvault/kv.azure.cn/MySecret?version=1.0
-
-# Azure Government
-rsec://myvault/kv.azure.us/MySecret?version=1.0
-
-# Azure Germany
-rsec://myvault/kv.azure.de/MySecret?version=1.0
-```
+For specific examples for your vault provider, see the relevant [Supported Secret Vaults](#supported-secret-vaults) subsection.
 
 ## Complete Example
 
@@ -254,18 +217,83 @@ rsec ref arn:aws:secretsmanager:us-east-1:012345678912:secret:MyApiKey
 **Limitations:**
 - Only supports string values (not binary)
 
+**Secret Reference Format**
+All AWS Secrets Manager references are constructed with the following values:
+```bash
+rsec://<accountNumber>/sm.aws/<secretName>?region=<region>
+```
+
+The `region` attribute is currently only applicable to AWS Secrets Manager references, and will appear on all secret references for this provider.
+
+Example:
+```
+rsec://012345678912/sm.aws/DatabasePassword?region=us-east-1
+```
+
 ### Azure Key Vault
 
 **Authentication:**
 - Uses standard Azure SDK authentication
 - Supports Azure CLI, Managed Identity, Service Principal
 
+**Secret Reference Format**
+For Azure Key Vault, the reference format is:
+```bash
+rsec://<vaultAddress>/kv.azure/<secretName>?<arguments>
+```
+
+Where:
+* `vaultAddress`: The name of the Azure Key Vault (e.g. if using `https://myvault.vault.azure.net/` then `myvault` is the vault address)
+* `secretName`: The name of the secret in the Azure Key Vault
+* `arguments`: Optional arguments, such as `version` to specify a specific version of the secret.
+
+Example:
+```
+rsec://myvault/kv.azure/MySecret?version=1.0
+```
+
+**Using Azure China/Azure Government/Azure Germany**
+If you are using Azure China, Azure Government, or Azure Germany, you can use `rsec` in the same way described above, but will replace the `kv.azure` with a region-specific value. For example, for Azure China, you would use `kv.azure.cn` instead of `kv.azure`. Example secret references for each Azure region is as follows:
+```bash
+# Azure China
+rsec://myvault/kv.azure.cn/MySecret?version=1.0
+
+# Azure Government
+rsec://myvault/kv.azure.us/MySecret?version=1.0
+
+# Azure Germany
+rsec
+
+### HashiCorp Vault
+
+Supports both versions of the KV secret engine (v1 and v2) and credential-based secret enginees such as database, aws, rabbitmq, etc.
+
+**Authentication:**
+- Currently supports token-based authentication via one of the following methods:
+  - The `VAULT_TOKEN` environment variable
+  - Tokens set in the `~/.vault-token` file (via userpass authentication)
+
+**Limitations**
+- Currently returns the entire secret object, not just the value. This will be addressed in [issue #8](https://github.com/runsecret/rsec/issues/8).
+
+**Secret Reference Format**
+For HashiCorp Vault, the reference format may look like one of the following:
+```bash
+rsec://<mountPath>/kv1.hashi/<secretName>?<arguments>
+rsec://<mountPath>/kv2.hashi/<secretName>?<arguments>
+rsec://<mountPath>/cred.hashi/<secretName>?<arguments>
+```
+
+Where:
+* `mountPath`: The path where the secret or credential is mounted in HashiCorp Vault.
+* `secretName`: The name of the secret in HashiCorp Vault
+* `arguments`: Optional arguments
+  * `endpoint`: The URL encoded endpoint to the HashiCorp Vault server (e.g. `https://vault.example.com`). If not set, will default to the `VAULT_ADDR` environment variable.
+
 
 ### Upcoming Vault Support (Roadmap)
 - GCP Secret Manager
 - AWS Parameter Store
-- HashiCorp Vault
-
 
 ## Uninstalling
 We recommend using the same method you used to install RunSecret to uninstall it. For example, if you installed it with Homebrew, you can uninstall it with:

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -18,6 +18,7 @@ func TestCopyCommand(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Set up command arguments
 	cmd.SetArgs([]string{"rsec://000000000000/sm.aws/test/api/keys?region=us-east-1"})
@@ -41,6 +42,7 @@ func TestCopyCommand_Azure(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Set up command arguments
 	cmd.SetArgs([]string{"rsec://rsec-test/kv.azure/basic-secret"})
@@ -67,6 +69,7 @@ func TestCopyCommand_HashiCreds(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Set up command arguments
 	cmd.SetArgs([]string{"rsec://database/cred.hashi/readonly?endpoint=http%3A%2F%2Flocalhost%3A8200"})
@@ -93,6 +96,7 @@ func TestCopyCommand_HashiKVv2(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Set up command arguments
 	cmd.SetArgs([]string{"rsec://secret/kv2.hashi/my-secret?endpoint=http%3A%2F%2Flocalhost%3A8200"})
@@ -115,6 +119,7 @@ func TestCopyCommand_MissingArgument(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Execute command with no arguments
 	err := cmd.Execute()
@@ -126,6 +131,28 @@ func TestCopyCommand_MissingArgument(t *testing.T) {
 	require.NoError(err)
 }
 
+func TestCopyCommand_InvalidSecretRef(t *testing.T) {
+	require := require.New(t)
+	cmd := NewCopyCmd()
+
+	// Capture output
+	b := bytes.NewBufferString("")
+	cmd.SetOut(b)
+	cmd.SetErr(b)
+
+	// Set up invalid secret reference
+	cmd.SetArgs([]string{"invalid-secret-ref"})
+
+	// Execute command
+	err := cmd.Execute()
+	require.NoError(err)
+
+	// Ensure output indicates invalid reference
+	out, err := io.ReadAll(b)
+	require.NoError(err)
+	assert.Contains(t, string(out), "❌ - Invalid secret reference provided!")
+}
+
 func TestRunCommand(t *testing.T) {
 	t.Skip("GitHub Actions doesn't like pty")
 	require := require.New(t)
@@ -135,6 +162,7 @@ func TestRunCommand(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Set up command arguments
 	cmd.SetArgs([]string{"--", "echo", "password1234"})
@@ -167,6 +195,7 @@ func TestRunCommand_Azure(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Set up command arguments
 	cmd.SetArgs([]string{"--", "echo", "password1234"})
@@ -198,6 +227,7 @@ func TestRefCommand_AwsRef(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Set up command arguments
 	cmd.SetArgs([]string{"rsec://000000000000/sm.aws/test/api/keys?region=us-east-1"})
@@ -224,6 +254,7 @@ func TestRefCommand_AzureArn(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Set up command arguments
 	cmd.SetArgs([]string{"https://myvaultname.vault.azure.net/secrets/mysecretname/"})
@@ -250,6 +281,7 @@ func TestRefCommand_AzureRef(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Set up command arguments
 	cmd.SetArgs([]string{"rsec://myvaultname/kv.azure/mysecretname"})
@@ -276,6 +308,7 @@ func TestRefCommand_HashiKVv2Url(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Set up command arguments
 	cmd.SetArgs([]string{"http://localhost:8200/v1/secret/data/my-secret"})
@@ -302,6 +335,7 @@ func TestRefCommand_HashiCredentialUrl(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Set up command arguments
 	cmd.SetArgs([]string{"http://localhost:8200/v1/database/creds/readonly"})
@@ -328,6 +362,7 @@ func TestRefCommand_HashiRef(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Set up command arguments
 	cmd.SetArgs([]string{"rsec://secret/kv2.hashi/my-secret?endpoint=http%3A%2F%2Flocalhost%3A8200"})
@@ -354,6 +389,7 @@ func TestRefCommand_HashiRef_NoEndpoint(t *testing.T) {
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
+	cmd.SetErr(b)
 
 	// Set up command arguments
 	cmd.SetArgs([]string{"rsec://secret/kv2.hashi/my-secret"})
@@ -370,4 +406,26 @@ func TestRefCommand_HashiRef_NoEndpoint(t *testing.T) {
 		"Secret Reference:  rsec://secret/kv2.hashi/my-secret\nVault Address:\t   <VAULT_ADDR>/v1/secret/data/my-secret\n",
 		string(out),
 	)
+}
+
+func TestRefCommand_InvalidIdentifier(t *testing.T) {
+	require := require.New(t)
+	cmd := NewRefCmd()
+
+	// Capture output
+	b := bytes.NewBufferString("")
+	cmd.SetOut(b)
+	cmd.SetErr(b)
+
+	// Set up invalid identifier
+	cmd.SetArgs([]string{"invalid-identifier"})
+
+	// Execute command
+	err := cmd.Execute()
+	require.NoError(err)
+
+	// Ensure output indicates invalid identifier
+	out, err := io.ReadAll(b)
+	require.NoError(err)
+	assert.Contains(t, string(out), "Invalid secret identifier")
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -56,7 +56,7 @@ func TestCopyCommand_Azure(t *testing.T) {
 	assert.Equal("✓ - Secret copied to clipboard!\n", string(out))
 }
 
-func TestCopyCommand_Hashi(t *testing.T) {
+func TestCopyCommand_HashiCreds(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	cmd := NewCopyCmd()
@@ -66,7 +66,30 @@ func TestCopyCommand_Hashi(t *testing.T) {
 	cmd.SetOut(b)
 
 	// Set up command arguments
-	cmd.SetArgs([]string{"rsec://secret/kv2.hashi/my-project?endpoint=http%3A%2F%2Flocalhost%3A8200"})
+	cmd.SetArgs([]string{"rsec://database/cred.hashi/readonly?endpoint=http%3A%2F%2Flocalhost%3A8200"})
+
+	// Execute command
+	err := cmd.Execute()
+	// Expect no error
+	require.NoError(err)
+
+	// Ensure output is as expected
+	out, err := io.ReadAll(b)
+	require.NoError(err)
+	assert.Equal("✓ - Secret copied to clipboard!\n", string(out))
+}
+
+func TestCopyCommand_HashiKVv2(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	cmd := NewCopyCmd()
+
+	// Capture output
+	b := bytes.NewBufferString("")
+	cmd.SetOut(b)
+
+	// Set up command arguments
+	cmd.SetArgs([]string{"rsec://secret/kv2.hashi/my-secret?endpoint=http%3A%2F%2Flocalhost%3A8200"})
 
 	// Execute command
 	err := cmd.Execute()
@@ -239,7 +262,7 @@ func TestRefCommand_AzureRef(t *testing.T) {
 	)
 }
 
-func TestRefCommand_HashiUrl(t *testing.T) {
+func TestRefCommand_HashiKVv2Url(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	cmd := NewRefCmd()
@@ -249,7 +272,7 @@ func TestRefCommand_HashiUrl(t *testing.T) {
 	cmd.SetOut(b)
 
 	// Set up command arguments
-	cmd.SetArgs([]string{"http://localhost:8200/v1/secret/data/my-project"})
+	cmd.SetArgs([]string{"http://localhost:8200/v1/secret/data/my-secret"})
 
 	// Execute command
 	err := cmd.Execute()
@@ -260,7 +283,33 @@ func TestRefCommand_HashiUrl(t *testing.T) {
 	out, err := io.ReadAll(b)
 	require.NoError(err)
 	assert.Equal(
-		"Secret Reference:  rsec://secret/kv2.hashi/my-project?endpoint=http%3A%2F%2Flocalhost%3A8200\nVault Address:\t   http://localhost:8200/v1/secret/data/my-project\n",
+		"Secret Reference:  rsec://secret/kv2.hashi/my-secret?endpoint=http%3A%2F%2Flocalhost%3A8200\nVault Address:\t   http://localhost:8200/v1/secret/data/my-secret\n",
+		string(out),
+	)
+}
+
+func TestRefCommand_HashiCredentialUrl(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	cmd := NewRefCmd()
+
+	// Capture output
+	b := bytes.NewBufferString("")
+	cmd.SetOut(b)
+
+	// Set up command arguments
+	cmd.SetArgs([]string{"http://localhost:8200/v1/database/creds/readonly"})
+
+	// Execute command
+	err := cmd.Execute()
+	// Expect no error
+	require.NoError(err)
+
+	// Ensure output is as expected
+	out, err := io.ReadAll(b)
+	require.NoError(err)
+	assert.Equal(
+		"Secret Reference:  rsec://database/cred.hashi/readonly?endpoint=http%3A%2F%2Flocalhost%3A8200\nVault Address:\t   http://localhost:8200/v1/database/creds/readonly\n",
 		string(out),
 	)
 }
@@ -275,7 +324,7 @@ func TestRefCommand_HashiRef(t *testing.T) {
 	cmd.SetOut(b)
 
 	// Set up command arguments
-	cmd.SetArgs([]string{"rsec://secret/kv2.hashi/my-project?endpoint=http%3A%2F%2Flocalhost%3A8200"})
+	cmd.SetArgs([]string{"rsec://secret/kv2.hashi/my-secret?endpoint=http%3A%2F%2Flocalhost%3A8200"})
 
 	// Execute command
 	err := cmd.Execute()
@@ -286,7 +335,7 @@ func TestRefCommand_HashiRef(t *testing.T) {
 	out, err := io.ReadAll(b)
 	require.NoError(err)
 	assert.Equal(
-		"Secret Reference:  rsec://secret/kv2.hashi/my-project?endpoint=http%3A%2F%2Flocalhost%3A8200\nVault Address:\t   http://localhost:8200/v1/secret/data/my-project\n",
+		"Secret Reference:  rsec://secret/kv2.hashi/my-secret?endpoint=http%3A%2F%2Flocalhost%3A8200\nVault Address:\t   http://localhost:8200/v1/secret/data/my-secret\n",
 		string(out),
 	)
 }
@@ -301,7 +350,7 @@ func TestRefCommand_HashiRef_NoEndpoint(t *testing.T) {
 	cmd.SetOut(b)
 
 	// Set up command arguments
-	cmd.SetArgs([]string{"rsec://secret/kv2.hashi/my-project"})
+	cmd.SetArgs([]string{"rsec://secret/kv2.hashi/my-secret"})
 
 	// Execute command
 	err := cmd.Execute()
@@ -312,7 +361,7 @@ func TestRefCommand_HashiRef_NoEndpoint(t *testing.T) {
 	out, err := io.ReadAll(b)
 	require.NoError(err)
 	assert.Equal(
-		"Secret Reference:  rsec://secret/kv2.hashi/my-project\nVault Address:\t   <VAULT_ADDR>/v1/secret/data/my-project\n",
+		"Secret Reference:  rsec://secret/kv2.hashi/my-secret\nVault Address:\t   <VAULT_ADDR>/v1/secret/data/my-secret\n",
 		string(out),
 	)
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -61,6 +61,9 @@ func TestCopyCommand_HashiCreds(t *testing.T) {
 	assert := assert.New(t)
 	cmd := NewCopyCmd()
 
+	// Set token in env var
+	os.Setenv("VAULT_TOKEN", "dev-only-token")
+
 	// Capture output
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
@@ -83,6 +86,9 @@ func TestCopyCommand_HashiKVv2(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	cmd := NewCopyCmd()
+
+	// Set token in env var
+	os.Setenv("VAULT_TOKEN", "dev-only-token")
 
 	// Capture output
 	b := bytes.NewBufferString("")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,19 @@ services:
       - "8200:8200" # Vault API
     environment:
       - VAULT_DEV_ROOT_TOKEN_ID=dev-only-token
+  postgres:
+    container_name: "postgres"
+    image: postgres:latest
+    ports:
+      - "5432:5432" # PostgreSQL
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
+    volumes:
+      - ./local/postgres:/docker-entrypoint-initdb.d
   vault-prepopulate:
-    image: alpine/curl
+    image: hashicorp/vault:latest
     depends_on:
       - hashicorp-vault
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,5 +37,6 @@ services:
     depends_on:
       - hashicorp-vault
     volumes:
+      - ./local/vault/admin-policy.hcl:/usr/local/bin/admin-policy.hcl
       - ./local/vault/init-vault.sh:/usr/local/bin/init-vault.sh
     command: ["sh", "-c", "/usr/local/bin/init-vault.sh"]

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/creack/pty v1.1.24
 	github.com/hashicorp/vault/api v1.16.0
 	github.com/magefile/mage v1.15.0
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 )
@@ -48,7 +49,6 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/internal/vault/conversions_test.go
+++ b/internal/vault/conversions_test.go
@@ -16,8 +16,16 @@ func TestConvertAwsArnToRef(t *testing.T) {
 }
 
 func TestConvertHashiURLToRef_KV2(t *testing.T) {
-	testArn := "http://localhost:8200/v1/secret/data/my-project"
-	expectedRef := "rsec://secret/kv2.hashi/my-project?endpoint=http%3A%2F%2Flocalhost%3A8200"
+	testArn := "http://localhost:8200/v1/secret/data/my-secret"
+	expectedRef := "rsec://secret/kv2.hashi/my-secret?endpoint=http%3A%2F%2Flocalhost%3A8200"
+	ref, err := ConvertHashicorpVaultURLToRef(testArn)
+	require.NoError(t, err)
+	assert.Equal(t, expectedRef, ref)
+}
+
+func TestConvertHashiURLToRef_Creds(t *testing.T) {
+	testArn := "http://localhost:8200/v1/database/creds/my-role"
+	expectedRef := "rsec://database/cred.hashi/my-role?endpoint=http%3A%2F%2Flocalhost%3A8200"
 	ref, err := ConvertHashicorpVaultURLToRef(testArn)
 	require.NoError(t, err)
 	assert.Equal(t, expectedRef, ref)

--- a/local/vault/admin-policy.hcl
+++ b/local/vault/admin-policy.hcl
@@ -1,0 +1,146 @@
+# vault-admin-policy.hcl
+# This policy grants administrative capabilities to manage all aspects of Vault
+# while following the principle of least privilege where possible.
+
+# Allow management of the token store
+path "auth/token/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Allow management of all auth methods
+path "auth/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Allow management of all secret engines
+path "sys/mounts/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Allow management and usage of database secrets engine
+path "database/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# Allow access to database credentials
+path "database/creds/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# Allow database configuration
+path "database/config/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# Allow database roles management
+path "database/roles/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# Allow management of all policies
+path "sys/policies/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+path "sys/policy/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Allow listing and viewing all secrets
+path "secret/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# Allow management of KV secrets engine (v1 and v2)
+path "kv/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+path "+/data/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+path "+/metadata/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# Allow management of system configuration
+path "sys/config/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Allow management of system health and status
+path "sys/health" {
+  capabilities = ["read", "sudo"]
+}
+path "sys/seal" {
+  capabilities = ["read", "update", "sudo"]
+}
+path "sys/seal-status" {
+  capabilities = ["read"]
+}
+path "sys/unseal" {
+  capabilities = ["read", "update"]
+}
+
+# Allow management of audit devices
+path "sys/audit*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Allow management of leases
+path "sys/leases/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Allow management of storage
+path "sys/storage/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Allow management of capabilities and permissions
+path "sys/capabilities*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# Allow management of audit logs
+path "sys/audit-hash/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# Allow management of plugins
+path "sys/plugins*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Allow management of replication
+path "sys/replication/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Allow tools functionality
+path "sys/tools/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# Allow rotation of encryption keys
+path "sys/rotate" {
+  capabilities = ["update", "sudo"]
+}
+
+# Allow management of system initialization
+path "sys/init" {
+  capabilities = ["read", "update"]
+}
+
+# Allow root token generation (should be used very carefully)
+path "sys/generate-root/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Allow license management
+path "sys/license" {
+  capabilities = ["read", "update"]
+}
+
+# Allow reading metrics
+path "sys/metrics" {
+  capabilities = ["read"]
+}

--- a/local/vault/init-vault.sh
+++ b/local/vault/init-vault.sh
@@ -1,6 +1,25 @@
 sleep 2
-curl \
-    --header "X-Vault-Token: dev-only-token" \
-    --request POST \
-    --data '{ "data": {"pass": "my-password", "username":"my-username"} }' \
-    http://hashicorp-vault:8200/v1/secret/data/my-project
+# Initialize Vault
+# Set Token
+export VAULT_TOKEN=dev-only-token
+export VAULT_ADDR=http://hashicorp-vault:8200
+
+# Initialize secret in KVv2 engine
+vault kv put secret/my-secret \
+    username="my-username" \
+    pass="my-password"
+
+# Setup postgres database secret engine for testing
+vault secrets enable database
+vault write database/config/my-database \
+    plugin_name=postgresql-database-plugin \
+    allowed_roles="readonly" \
+    connection_url="postgresql://{{username}}:{{password}}@postgres:5432/postgres?sslmode=disable" \
+    username="postgres" \
+    password="postgres"
+vault write database/roles/readonly \
+    db_name=my-database \
+    creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';" \
+    default_ttl="1h" \
+    max_ttl="24h" \
+    revocation_statements="REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM \"{{name}}\";"

--- a/local/vault/init-vault.sh
+++ b/local/vault/init-vault.sh
@@ -23,3 +23,21 @@ vault write database/roles/readonly \
     default_ttl="1h" \
     max_ttl="24h" \
     revocation_statements="REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM \"{{name}}\";"
+
+# Create Admin policy
+vault policy write admin /usr/local/bin/admin-policy.hcl
+
+# Enable Userpass auth method
+vault auth enable userpass
+vault write auth/userpass/users/test-user \
+    password=my-password \
+    policies=admin
+
+# Enable AppRole auth method
+vault auth enable approle
+vault write auth/approle/role/test-role \
+    secret_id_ttl=60m \
+    token_num_uses=10 \
+    token_ttl=20m \
+    token_max_ttl=30m \
+    policies=admin

--- a/pkg/hashi/auth.go
+++ b/pkg/hashi/auth.go
@@ -1,0 +1,46 @@
+package hashi
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/mitchellh/go-homedir"
+)
+
+// authenticateWithToken authenticates using a token
+func authenticateWithToken(client *vault.Client) error {
+	var token string
+
+	// Try to get token from environment variable
+	token = os.Getenv("VAULT_TOKEN")
+	if token != "" {
+		client.SetToken(token)
+		return nil
+	}
+
+	// Try to read token from default token file
+	home, err := homedir.Dir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+	tokenPath := filepath.Join(home, ".vault-token")
+
+	// Check if token file exists
+	if _, err := os.Stat(tokenPath); os.IsNotExist(err) {
+		return errors.New("no token found in ~/.vault-token or VAULT_TOKEN environment variable")
+	}
+
+	// Read token from file
+	tokenBytes, err := os.ReadFile(tokenPath)
+	if err != nil {
+		return fmt.Errorf("failed to read token file: %w", err)
+	}
+
+	token = strings.TrimSpace(string(tokenBytes))
+	client.SetToken(token)
+	return nil
+}

--- a/pkg/hashi/vault.go
+++ b/pkg/hashi/vault.go
@@ -53,8 +53,10 @@ func (h *Vault) getClient(ref secretref.SecretReference) VaultClientAPI {
 			log.Fatalf("Cannot connect to HashiCorp Vault client: %s", err)
 		}
 
-		// TODO: Replace with real auth
-		client.SetToken("dev-only-token")
+		err = authenticateWithToken(client)
+		if err != nil {
+			log.Fatalf("Failed to authenticate with Vault: %s", err)
+		}
 
 		h.client = &vaultClientWrapper{client: client}
 	}

--- a/pkg/hashi/vault_test.go
+++ b/pkg/hashi/vault_test.go
@@ -19,7 +19,7 @@ func TestHashiVault_GetKv1Secret_Success(t *testing.T) {
 	hv := &Vault{client: mockVaultClient}
 
 	// Setup secret reference
-	secretRef := secretref.New("vault", secretref.VaultTypeHashicorpVaultKv2, "secret/my-project")
+	secretRef := secretref.New("vault", secretref.VaultTypeHashicorpVaultKv2, "secret/my-secret")
 
 	secret, err := hv.GetKv1Secret(secretRef)
 	require.NoError(t, err)
@@ -33,7 +33,7 @@ func TestHashiVault_GetKv1Secret_ErrorFetchingSecret(t *testing.T) {
 	hv := &Vault{client: mockVaultClient}
 
 	// Setup secret reference
-	secretRef := secretref.New("vault", secretref.VaultTypeHashicorpVaultKv2, "secret/my-project")
+	secretRef := secretref.New("vault", secretref.VaultTypeHashicorpVaultKv2, "secret/my-secret")
 
 	_, err := hv.GetKv1Secret(secretRef)
 	require.Error(t, err)
@@ -41,7 +41,7 @@ func TestHashiVault_GetKv1Secret_ErrorFetchingSecret(t *testing.T) {
 }
 
 func TestHashiVault_GetKv2Secret_Success(t *testing.T) {
-	mockData := map[string]interface{}{
+	mockData := map[string]any{
 		"password": "test-password",
 	}
 	mockKVClient := &mockHashiKVClient{mockData: mockData, mockErr: nil}
@@ -50,7 +50,7 @@ func TestHashiVault_GetKv2Secret_Success(t *testing.T) {
 	hv := &Vault{client: mockVaultClient}
 
 	// Setup secret reference
-	secretRef := secretref.New("vault", secretref.VaultTypeHashicorpVaultKv2, "secret/my-project")
+	secretRef := secretref.New("vault", secretref.VaultTypeHashicorpVaultKv2, "secret/my-secret")
 
 	secret, err := hv.GetKv2Secret(secretRef)
 	require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestHashiVault_GetKv2Secret_ErrorFetchingSecret(t *testing.T) {
 	hv := &Vault{client: mockVaultClient}
 
 	// Setup secret reference
-	secretRef := secretref.New("vault", secretref.VaultTypeHashicorpVaultKv2, "secret/my-project")
+	secretRef := secretref.New("vault", secretref.VaultTypeHashicorpVaultKv2, "secret/my-secret")
 
 	_, err := hv.GetKv2Secret(secretRef)
 	require.Error(t, err)
@@ -72,7 +72,7 @@ func TestHashiVault_GetKv2Secret_ErrorFetchingSecret(t *testing.T) {
 }
 
 func TestHashiVault_GetCredentials_Success(t *testing.T) {
-	mockData := map[string]interface{}{
+	mockData := map[string]any{
 		"username": "db_username",
 	}
 	mockLogicalClient := &mockHashiLogicalClient{mockData: mockData, mockErr: nil}
@@ -81,7 +81,7 @@ func TestHashiVault_GetCredentials_Success(t *testing.T) {
 	hv := &Vault{client: mockVaultClient}
 
 	// Setup secret reference
-	secretRef := secretref.New("vault", secretref.VaultTypeHashicorpVaultKv2, "secret/my-project")
+	secretRef := secretref.New("vault", secretref.VaultTypeHashicorpVaultKv2, "secret/my-secret")
 
 	secret, err := hv.GetCredential(secretRef)
 	require.NoError(t, err)
@@ -95,7 +95,7 @@ func TestHashiVault_GetCredential_ErrorFetchingSecret(t *testing.T) {
 	hv := &Vault{client: mockVaultClient}
 
 	// Setup secret reference
-	secretRef := secretref.New("vault", secretref.VaultTypeHashicorpVaultKv2, "secret/my-project")
+	secretRef := secretref.New("vault", secretref.VaultTypeHashicorpVaultKv2, "secret/my-secret")
 
 	_, err := hv.GetCredential(secretRef)
 	require.Error(t, err)


### PR DESCRIPTION
Rounds out the Hashicorp Vault implementation with:
- Support for token-based auth (will add more methods in the future)
- Credential secret integration/cmd tests added
- Documentation in the README

Merging this closes #11 